### PR TITLE
Enabling alternate task lists for the same type

### DIFF
--- a/main.js
+++ b/main.js
@@ -600,6 +600,7 @@ function _select_Gateway() { // Check for Gateway used to
     var defaultTasklist = [
         {
             // modded to prioritize RAD production, added low level task for speeding up levelling up
+            taskListName: "Leadership",
             taskName: "Leadership",
             level: {
                 0: ["Leadership_Tier0_Intro_1"],
@@ -629,8 +630,36 @@ function _select_Gateway() { // Check for Gateway used to
                 20: ["Leadership_Tier3_20r_Master2", "Leadership_Tier3_20r_Master1", "Leadership_Tier3_20r_Master3", "Leadership_Tier3_20_Destroy", "Leadership_Tier3_13r_Protectdiamonds", "Leadership_Tier2_12_Taxes", "Leadership_Tier3_16_Fight", "Leadership_Tier2_10_Battle", "Leadership_Tier3_13_Patrol", "Leadership_Tier2_9_Chart", "Leadership_Tier1_5_Explore"],
             },
         },
+		{
+			taskListName: "Leadership_XP",
+			taskName: "Leadership",
+			level: {
+				0: ["Leadership_Tier0_Intro_1"],
+				1: ["Leadership_Tier0_Intro_5", "Leadership_Tier0_Intro_4", "Leadership_Tier0_Intro_3", "Leadership_Tier0_Intro_2"],
+				2: ["Leadership_Tier1_Feedtheneedy", "Leadership_Tier1_2_Guardduty", "Leadership_Tier1_2_Training"],
+				3: ["Leadership_Tier1_Feedtheneedy", "Leadership_Tier1_2_Guardduty", "Leadership_Tier1_2_Training"],
+				4: ["Leadership_Tier1_Feedtheneedy", "Leadership_Tier1_4_Protect", "Leadership_Tier1_2_Guardduty", "Leadership_Tier1_2_Training"],
+				5: ["Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier1_2_Guardduty"],
+				6: ["Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier1_2_Guardduty"],
+				7: ["Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier1_2_Guardduty"],
+				8: ["Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier1_2_Guardduty"],
+				9: ["Leadership_Tier1_5_Explore", "Leadership_Tier2_9_Chart", "Leadership_Tier1_4_Protect"],
+				10: ["Leadership_Tier2_9_Chart", "Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier1_2_Guardduty"],
+				11: ["Leadership_Tier2_9_Chart", "Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier1_2_Guardduty"],
+				12: ["Leadership_Tier2_9_Chart", "Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier1_2_Guardduty"],
+				13: ["Leadership_Tier3_13_Patrol", "Leadership_Tier2_9_Chart", "Leadership_Tier3_13_Training", "Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier2_7_Training"],
+				14: ["Leadership_Tier3_13_Patrol", "Leadership_Tier2_9_Chart", "Leadership_Tier3_13_Training", "Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier2_7_Training"],
+				15: ["Leadership_Tier3_13_Patrol", "Leadership_Tier2_9_Chart", "Leadership_Tier3_13_Training", "Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier2_7_Training"],
+				16: ["Leadership_Tier3_13_Patrol", "Leadership_Tier2_9_Chart", "Leadership_Tier3_13_Training", "Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier2_7_Training"],
+				17: ["Leadership_Tier3_13_Patrol", "Leadership_Tier2_9_Chart", "Leadership_Tier3_13_Training", "Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier2_7_Training"],
+				18: ["Leadership_Tier3_13_Patrol", "Leadership_Tier2_9_Chart", "Leadership_Tier3_13_Training", "Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier2_7_Training"],
+				19: ["Leadership_Tier3_13_Patrol", "Leadership_Tier2_9_Chart", "Leadership_Tier3_13_Training", "Leadership_Tier1_5_Explore", "Leadership_Tier1_4_Protect", "Leadership_Tier2_7_Training"],
+				20: ["Leadership_Tier3_13r_Protectdiamonds", "Leadership_Tier3_20r_Master2", "Leadership_Tier3_20r_Master1", "Leadership_Tier3_20r_Master3", "Leadership_Tier3_20_Destroy", "Leadership_Tier2_12_Taxes","Leadership_Tier3_16_Fight", "Leadership_Tier2_10_Battle", "Leadership_Tier3_13_Patrol"],
+			},
+		},
         {
             //WinterEvent
+            taskListName: "WinterEvent",
             taskName: "WinterEvent",
             level: {
                 0: ["Event_Winter_Tier0_Intro"],
@@ -640,6 +669,7 @@ function _select_Gateway() { // Check for Gateway used to
             },
         },
         {
+        	taskListName: "Event_Siege",
             taskName:"Event_Siege",
             level: {
                 0:["Event_Siege_Tier0_Intro"], // Hire a Siege Master
@@ -655,6 +685,7 @@ function _select_Gateway() { // Check for Gateway used to
         },
         {
             // Black Ice Shaping
+            taskListName: "BlackIce",
             taskName: "BlackIce",
             level: {
                 1: ["Blackice_Tier1_Process_Blackice"],
@@ -669,6 +700,7 @@ function _select_Gateway() { // Check for Gateway used to
         },
         {
             // Jewelcrafting
+            taskListName: "Jewelcrafting",
             taskName: "Jewelcrafting",
             level: {
                 0: ["Jewelcrafting_Tier0_Intro"],
@@ -696,6 +728,7 @@ function _select_Gateway() { // Check for Gateway used to
         },
         {
             // Mailsmithing
+            taskListName: "Mailsmithing",
             taskName: "Armorsmithing_Med",
             level: {
                 0: ["Med_Armorsmithing_Tier0_Intro"],
@@ -725,6 +758,7 @@ function _select_Gateway() { // Check for Gateway used to
         },
         {
             // Platesmithing
+            taskListName: "Platesmithing",
             taskName: "Armorsmithing_Heavy",
             level: {
                 0: ["Hvy_Armorsmithing_Tier0_Intro"],
@@ -753,6 +787,7 @@ function _select_Gateway() { // Check for Gateway used to
             },
         },
         {
+        	taskListName: "Leatherworking",
             taskName: "Leatherworking",
             level: {
                 0: ["Leatherworking_Tier0_Intro_1"],
@@ -781,6 +816,7 @@ function _select_Gateway() { // Check for Gateway used to
             },
         },
         {
+        	taskListName: "Tailoring",
             taskName: "Tailoring",
             level: {
                 0: ["Tailoring_Tier0_Intro"],
@@ -809,6 +845,7 @@ function _select_Gateway() { // Check for Gateway used to
             },
         },
         {
+        	taskListName: "Artificing",
             taskName: "Artificing",
             level: {
                 0: ["Artificing_Tier0_Intro_1"],
@@ -837,6 +874,7 @@ function _select_Gateway() { // Check for Gateway used to
             },
         },
         {
+        	taskListName: "Weaponsmithing",
             taskName: "Weaponsmithing",
             level: {
                 0: ["Weaponsmithing_Tier0_Intro"],
@@ -865,6 +903,7 @@ function _select_Gateway() { // Check for Gateway used to
             },
         },
         {
+        	taskListName: "Alchemy",
             taskName: "Alchemy",
             level: {
                 0: ["Alchemy_Tier0_Intro_1"],
@@ -966,6 +1005,7 @@ function _select_Gateway() { // Check for Gateway used to
         charSettings.push({name: 'Artificing' + i, title: 'Artificing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Artificing'});
         charSettings.push({name: 'Weaponsmithing' + i, title: 'Weaponsmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Weaponsmithing'});
         charSettings.push({name: 'Alchemy' + i, title: 'Alchemy', def: '0', type: 'text', tooltip: 'Number of slots to assign to Alchemy'});
+		charSettings.push({name: 'Leadership_XP' + i, title: 'Leadership XP', def: '0', type: 'text', tooltip: 'Number of slots to assign to Leadership focused on XP'});
 
         // task settings are slightly different
         charSettings.push({name: 'tasklist' + i, title: 'Task List', def: '', type: 'void', tooltip: ''});
@@ -1044,11 +1084,11 @@ function _select_Gateway() { // Check for Gateway used to
             }).length) {
             // Go through the professions to assign tasks until specified slots filled
             for (var i = 0; i < tasklist.length; i++) {
-                if (settings[tasklist[i].taskName] > 0) { //MAC-NW
+                if (settings[tasklist[i].taskListName] > 0) { //MAC-NW
                     var currentTasks = unsafeWindow.client.dataModel.model.ent.main.itemassignments.assignments.filter(function (entry) {
                         return entry.category == tasklist[i].taskName;
                     });
-                    if (currentTasks.length < settings[tasklist[i].taskName]) {
+                    if (currentTasks.length < settings[tasklist[i].taskListName]) {
                         unsafeWindow.client.professionFetchTaskList('craft_' + tasklist[i].taskName);
                         window.setTimeout(function () {
                             createNextTask(tasklist[i], 0);

--- a/main.js
+++ b/main.js
@@ -998,14 +998,14 @@ function _select_Gateway() { // Check for Gateway used to
         charSettings.push({name: 'Leadership' + i, title: 'Leadership', def: '9', type: 'text', tooltip: 'Number of slots to assign to Leadership'});
         charSettings.push({name: 'BlackIce' + i, title: 'Black Ice Shaping', def: '0', type: 'text', tooltip: 'Number of slots to assign to BIS'});
         charSettings.push({name: 'Jewelcrafting' + i, title: 'Jewelcrafting', def: '0', type: 'text', tooltip: 'Number of slots to assign to Jewelcrafting'});
-        charSettings.push({name: 'Armorsmithing_Med' + i, title: 'Mailsmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Mailsmithing'});
-        charSettings.push({name: 'Armorsmithing_Heavy' + i, title: 'Platesmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Platesmithing'});
+	charSettings.push({name: 'Mailsmithing' + i, title: 'Mailsmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Mailsmithing'});
+	charSettings.push({name: 'Platesmithing' + i, title: 'Platesmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Platesmithing'});
         charSettings.push({name: 'Leatherworking' + i, title: 'Leatherworking', def: '0', type: 'text', tooltip: 'Number of slots to assign to Leatherworking'});
         charSettings.push({name: 'Tailoring' + i, title: 'Tailoring', def: '0', type: 'text', tooltip: 'Number of slots to assign to Tailoring'});
         charSettings.push({name: 'Artificing' + i, title: 'Artificing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Artificing'});
         charSettings.push({name: 'Weaponsmithing' + i, title: 'Weaponsmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Weaponsmithing'});
         charSettings.push({name: 'Alchemy' + i, title: 'Alchemy', def: '0', type: 'text', tooltip: 'Number of slots to assign to Alchemy'});
-		charSettings.push({name: 'Leadership_XP' + i, title: 'Leadership XP', def: '0', type: 'text', tooltip: 'Number of slots to assign to Leadership focused on XP'});
+	charSettings.push({name: 'Leadership_XP' + i, title: 'Leadership XP', def: '0', type: 'text', tooltip: 'Number of slots to assign to Leadership focused on XP'});
 
         // task settings are slightly different
         charSettings.push({name: 'tasklist' + i, title: 'Task List', def: '', type: 'void', tooltip: ''});

--- a/main.js
+++ b/main.js
@@ -600,7 +600,7 @@ function _select_Gateway() { // Check for Gateway used to
     var defaultTasklist = [
         {
             // modded to prioritize RAD production, added low level task for speeding up levelling up
-            taskListName: "Leadership",
+			taskListName: "Leadership",
             taskName: "Leadership",
             level: {
                 0: ["Leadership_Tier0_Intro_1"],
@@ -659,7 +659,7 @@ function _select_Gateway() { // Check for Gateway used to
 		},
         {
             //WinterEvent
-            taskListName: "WinterEvent",
+			taskListName: "WinterEvent",
             taskName: "WinterEvent",
             level: {
                 0: ["Event_Winter_Tier0_Intro"],
@@ -669,7 +669,7 @@ function _select_Gateway() { // Check for Gateway used to
             },
         },
         {
-        	taskListName: "Event_Siege",
+			taskListName: "Event_Siege",
             taskName:"Event_Siege",
             level: {
                 0:["Event_Siege_Tier0_Intro"], // Hire a Siege Master
@@ -685,7 +685,7 @@ function _select_Gateway() { // Check for Gateway used to
         },
         {
             // Black Ice Shaping
-            taskListName: "BlackIce",
+			taskListName: "BlackIce",
             taskName: "BlackIce",
             level: {
                 1: ["Blackice_Tier1_Process_Blackice"],
@@ -700,7 +700,7 @@ function _select_Gateway() { // Check for Gateway used to
         },
         {
             // Jewelcrafting
-            taskListName: "Jewelcrafting",
+			taskListName: "Jewelcrafting",
             taskName: "Jewelcrafting",
             level: {
                 0: ["Jewelcrafting_Tier0_Intro"],
@@ -728,7 +728,7 @@ function _select_Gateway() { // Check for Gateway used to
         },
         {
             // Mailsmithing
-            taskListName: "Mailsmithing",
+			taskListName: "Mailsmithing",
             taskName: "Armorsmithing_Med",
             level: {
                 0: ["Med_Armorsmithing_Tier0_Intro"],
@@ -758,7 +758,7 @@ function _select_Gateway() { // Check for Gateway used to
         },
         {
             // Platesmithing
-            taskListName: "Platesmithing",
+			taskListName: "Platesmithing",
             taskName: "Armorsmithing_Heavy",
             level: {
                 0: ["Hvy_Armorsmithing_Tier0_Intro"],
@@ -787,7 +787,7 @@ function _select_Gateway() { // Check for Gateway used to
             },
         },
         {
-        	taskListName: "Leatherworking",
+			taskListName: "Leatherworking",
             taskName: "Leatherworking",
             level: {
                 0: ["Leatherworking_Tier0_Intro_1"],
@@ -816,7 +816,7 @@ function _select_Gateway() { // Check for Gateway used to
             },
         },
         {
-        	taskListName: "Tailoring",
+			taskListName: "Tailoring",
             taskName: "Tailoring",
             level: {
                 0: ["Tailoring_Tier0_Intro"],
@@ -845,7 +845,7 @@ function _select_Gateway() { // Check for Gateway used to
             },
         },
         {
-        	taskListName: "Artificing",
+			taskListName: "Artificing",
             taskName: "Artificing",
             level: {
                 0: ["Artificing_Tier0_Intro_1"],
@@ -874,7 +874,7 @@ function _select_Gateway() { // Check for Gateway used to
             },
         },
         {
-        	taskListName: "Weaponsmithing",
+			taskListName: "Weaponsmithing",
             taskName: "Weaponsmithing",
             level: {
                 0: ["Weaponsmithing_Tier0_Intro"],
@@ -903,7 +903,7 @@ function _select_Gateway() { // Check for Gateway used to
             },
         },
         {
-        	taskListName: "Alchemy",
+    		taskListName: "Alchemy",
             taskName: "Alchemy",
             level: {
                 0: ["Alchemy_Tier0_Intro_1"],
@@ -992,23 +992,23 @@ function _select_Gateway() { // Check for Gateway used to
 
     var charSettings = [];
     for (var i = 0; i < settings["charcount"]; i++) {
-        charSettings.push({name: 'nw_charname' + i, title: 'Character', def: 'Character ' + (i + 1), type: 'text', tooltip: 'Characters Name'});
-        //charSettings.push({name: 'WinterEvent' + i, title: 'WinterEvent', def: '0', type: 'text', tooltip: 'Number of slots to assign to WinterEvent'});
-        charSettings.push({name: 'Event_Siege' + i, title: 'Siege Event', def: '0', type: 'text', tooltip: 'Number of slots to assign to Siege Event'});
-        charSettings.push({name: 'Leadership' + i, title: 'Leadership', def: '9', type: 'text', tooltip: 'Number of slots to assign to Leadership'});
-        charSettings.push({name: 'BlackIce' + i, title: 'Black Ice Shaping', def: '0', type: 'text', tooltip: 'Number of slots to assign to BIS'});
-        charSettings.push({name: 'Jewelcrafting' + i, title: 'Jewelcrafting', def: '0', type: 'text', tooltip: 'Number of slots to assign to Jewelcrafting'});
+	    charSettings.push({name: 'nw_charname' + i, title: 'Character', def: 'Character ' + (i + 1), type: 'text', tooltip: 'Characters Name'});
+	    //charSettings.push({name: 'WinterEvent' + i, title: 'WinterEvent', def: '0', type: 'text', tooltip: 'Number of slots to assign to WinterEvent'});
+	    charSettings.push({name: 'Event_Siege' + i, title: 'Siege Event', def: '0', type: 'text', tooltip: 'Number of slots to assign to Siege Event'});
+	    charSettings.push({name: 'Leadership' + i, title: 'Leadership', def: '9', type: 'text', tooltip: 'Number of slots to assign to Leadership'});
+	    charSettings.push({name: 'BlackIce' + i, title: 'Black Ice Shaping', def: '0', type: 'text', tooltip: 'Number of slots to assign to BIS'});
+	    charSettings.push({name: 'Jewelcrafting' + i, title: 'Jewelcrafting', def: '0', type: 'text', tooltip: 'Number of slots to assign to Jewelcrafting'});
 		charSettings.push({name: 'Mailsmithing' + i, title: 'Mailsmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Mailsmithing'});
 		charSettings.push({name: 'Platesmithing' + i, title: 'Platesmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Platesmithing'});
-        charSettings.push({name: 'Leatherworking' + i, title: 'Leatherworking', def: '0', type: 'text', tooltip: 'Number of slots to assign to Leatherworking'});
-        charSettings.push({name: 'Tailoring' + i, title: 'Tailoring', def: '0', type: 'text', tooltip: 'Number of slots to assign to Tailoring'});
-        charSettings.push({name: 'Artificing' + i, title: 'Artificing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Artificing'});
-        charSettings.push({name: 'Weaponsmithing' + i, title: 'Weaponsmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Weaponsmithing'});
-        charSettings.push({name: 'Alchemy' + i, title: 'Alchemy', def: '0', type: 'text', tooltip: 'Number of slots to assign to Alchemy'});
+	    charSettings.push({name: 'Leatherworking' + i, title: 'Leatherworking', def: '0', type: 'text', tooltip: 'Number of slots to assign to Leatherworking'});
+	    charSettings.push({name: 'Tailoring' + i, title: 'Tailoring', def: '0', type: 'text', tooltip: 'Number of slots to assign to Tailoring'});
+	    charSettings.push({name: 'Artificing' + i, title: 'Artificing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Artificing'});
+	    charSettings.push({name: 'Weaponsmithing' + i, title: 'Weaponsmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Weaponsmithing'});
+	    charSettings.push({name: 'Alchemy' + i, title: 'Alchemy', def: '0', type: 'text', tooltip: 'Number of slots to assign to Alchemy'});
 		charSettings.push({name: 'Leadership_XP' + i, title: 'Leadership XP', def: '0', type: 'text', tooltip: 'Number of slots to assign to Leadership focused on XP'});
-
-        // task settings are slightly different
-        charSettings.push({name: 'tasklist' + i, title: 'Task List', def: '', type: 'void', tooltip: ''});
+	
+	    // task settings are slightly different
+	    charSettings.push({name: 'tasklist' + i, title: 'Task List', def: '', type: 'void', tooltip: ''});
     }
 
     for (var i = 0; i < charSettings.length; i++) {

--- a/main.js
+++ b/main.js
@@ -998,14 +998,14 @@ function _select_Gateway() { // Check for Gateway used to
         charSettings.push({name: 'Leadership' + i, title: 'Leadership', def: '9', type: 'text', tooltip: 'Number of slots to assign to Leadership'});
         charSettings.push({name: 'BlackIce' + i, title: 'Black Ice Shaping', def: '0', type: 'text', tooltip: 'Number of slots to assign to BIS'});
         charSettings.push({name: 'Jewelcrafting' + i, title: 'Jewelcrafting', def: '0', type: 'text', tooltip: 'Number of slots to assign to Jewelcrafting'});
-	charSettings.push({name: 'Mailsmithing' + i, title: 'Mailsmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Mailsmithing'});
-	charSettings.push({name: 'Platesmithing' + i, title: 'Platesmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Platesmithing'});
+		charSettings.push({name: 'Mailsmithing' + i, title: 'Mailsmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Mailsmithing'});
+		charSettings.push({name: 'Platesmithing' + i, title: 'Platesmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Platesmithing'});
         charSettings.push({name: 'Leatherworking' + i, title: 'Leatherworking', def: '0', type: 'text', tooltip: 'Number of slots to assign to Leatherworking'});
         charSettings.push({name: 'Tailoring' + i, title: 'Tailoring', def: '0', type: 'text', tooltip: 'Number of slots to assign to Tailoring'});
         charSettings.push({name: 'Artificing' + i, title: 'Artificing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Artificing'});
         charSettings.push({name: 'Weaponsmithing' + i, title: 'Weaponsmithing', def: '0', type: 'text', tooltip: 'Number of slots to assign to Weaponsmithing'});
         charSettings.push({name: 'Alchemy' + i, title: 'Alchemy', def: '0', type: 'text', tooltip: 'Number of slots to assign to Alchemy'});
-	charSettings.push({name: 'Leadership_XP' + i, title: 'Leadership XP', def: '0', type: 'text', tooltip: 'Number of slots to assign to Leadership focused on XP'});
+		charSettings.push({name: 'Leadership_XP' + i, title: 'Leadership XP', def: '0', type: 'text', tooltip: 'Number of slots to assign to Leadership focused on XP'});
 
         // task settings are slightly different
         charSettings.push({name: 'tasklist' + i, title: 'Task List', def: '', type: 'void', tooltip: ''});


### PR DESCRIPTION
The version numbering was not touched.
It's a very small change and the only issue i see with this type of change is that working slots will be counted per the task type and not list name, so if using several leadership lists (for example) it is better to use one or the another per char, and not both (or more) at the same time.
I tried to fix the indent in the editor, but it looks as it should in the fork and it doesn't in the comparison preview.
