### PR TITLE
Daily reset detection for SCA

### DIFF
--- a/main.js
+++ b/main.js
@@ -1819,7 +1819,7 @@ function _select_Gateway() { // Check for Gateway used to
         {scope: 'account', group: 'generalSettings', name: 'runSCA', title: tr('settings.account.runSCA'),               type: 'select',   pane: 'main', tooltip: tr('settings.account.runSCA.tooltip'),
             opts: [ { name: 'never',        value: 'never'}, 
                     { name: 'free time',    value: 'free'}, 
-                    { name: 'after server reset',   value: 'once'},
+                    { name: 'reset detection (testing purpose)',   value: 'once'},
                     { name: 'always',       value: 'always'}],
             },        
         {scope: 'account', group: 'professionSettings', name: 'fillOptionals',   type: 'checkbox', pane: 'prof',    title: 'Fill Optional Assets',  tooltip: 'Enable to include selecting the optional assets of tasks'},
@@ -1856,7 +1856,7 @@ function _select_Gateway() { // Check for Gateway used to
         {scope: 'char', group: 'generalSettings', name: 'runSCA',    title: 'Run SCA',               type: 'select',   pane: 'main', tooltip: 'Running SCA adventures reward after professions',
             opts: [ { name: 'never',        value: 'never'}, 
                     { name: 'free time',    value: 'free'}, 
-                    { name: 'after server reset',   value: 'once'},
+                    { name: 'reset detection (testing purpose)',   value: 'once'},
                     { name: 'always',       value: 'always'}],
             },        
         

--- a/main.js
+++ b/main.js
@@ -2932,6 +2932,7 @@ function _select_Gateway() { // Check for Gateway used to
         if (newRefineToday < oldRefineToday) {
 			if (accountSettings.generalSettings.SCADailyReset < Date.now() - 16*60*60*1000) {
 				accountSettings.generalSettings.SCADailyReset = Date.now();
+				GM_setValue("settings__account__" + loggedAccount, JSON.stringify(accountSettings));
 			}
 		}
 

--- a/main.js
+++ b/main.js
@@ -2928,6 +2928,15 @@ function _select_Gateway() { // Check for Gateway used to
 
     function switchChar() {
 
+        // detect if daily reset occurs (no more frequently than every 16 hours)
+        var oldRefineToday = charStatisticsList[curCharName].general.refined | 0;
+        var newRefineToday = unsafeWindow.client.dataModel.model.ent.main.currencies.diamondsconverted | 0;
+        if (newRefineToday < oldRefineToday) {
+			if (accountSettings.generalSettings.SCADailyReset < Date.now() - 16*60*60*1000) {
+				accountSettings.generalSettings.SCADailyReset = Date.now();
+			}
+		}
+
         if (getSetting('generalSettings', 'refineAD')) {
             var _currencies = unsafeWindow.client.dataModel.model.ent.main.currencies;
             if (_currencies.diamondsconvertleft && _currencies.roughdiamonds) {
@@ -2995,15 +3004,6 @@ function _select_Gateway() { // Check for Gateway used to
         vendorJunk();
 
         // MAC-NW (endchanges)
-
-        // detect when daily reset occurs (no more frequently than every 16 hours)
-        var oldRefineToday = charStatisticsList[curCharName].general.refined | 0;
-        var newRefineToday = unsafeWindow.client.dataModel.model.ent.main.currencies.diamondsconverted | 0;
-        if (newRefineToday < oldRefineToday) {
-			if (accountSettings.generalSettings.SCADailyReset < Date.now() - 16*60*60*1000) {
-				accountSettings.generalSettings.SCADailyReset = Date.now();
-			}
-		}
 
         // Updating statistics
         var _stat = charStatisticsList[curCharName].general;

--- a/main.js
+++ b/main.js
@@ -1629,6 +1629,7 @@ function _select_Gateway() { // Check for Gateway used to
             refineAD: true,
             openRewards: false,
             runSCA: 'free',
+            SCADailyReset: Date.now() - 24*60*60*1000,
         },
         consolidationSettings: {
             bankCharName: "",
@@ -1818,6 +1819,7 @@ function _select_Gateway() { // Check for Gateway used to
         {scope: 'account', group: 'generalSettings', name: 'runSCA', title: tr('settings.account.runSCA'),               type: 'select',   pane: 'main', tooltip: tr('settings.account.runSCA.tooltip'),
             opts: [ { name: 'never',        value: 'never'}, 
                     { name: 'free time',    value: 'free'}, 
+                    { name: 'once daily',   value: 'once'},
                     { name: 'always',       value: 'always'}],
             },        
         {scope: 'account', group: 'professionSettings', name: 'fillOptionals',   type: 'checkbox', pane: 'prof',    title: 'Fill Optional Assets',  tooltip: 'Enable to include selecting the optional assets of tasks'},
@@ -1854,6 +1856,7 @@ function _select_Gateway() { // Check for Gateway used to
         {scope: 'char', group: 'generalSettings', name: 'runSCA',    title: 'Run SCA',               type: 'select',   pane: 'main', tooltip: 'Running SCA adventures reward after professions',
             opts: [ { name: 'never',        value: 'never'}, 
                     { name: 'free time',    value: 'free'}, 
+                    { name: 'once daily',   value: 'once'},
                     { name: 'always',       value: 'always'}],
             },        
         
@@ -2993,6 +2996,14 @@ function _select_Gateway() { // Check for Gateway used to
 
         // MAC-NW (endchanges)
 
+        // detect when daily reset occurs (no more frequently than every 16 hours)
+        var oldRefineToday = charStatisticsList[curCharName].general.refined | 0;
+        var newRefineToday = unsafeWindow.client.dataModel.model.ent.main.currencies.diamondsconverted | 0;
+        if (newRefineToday < oldRefineToday) {
+			if (accountSettings.generalSettings.SCADailyReset < Date.now() - 16*60*60*1000) {
+				accountSettings.generalSettings.SCADailyReset = Date.now();
+			}
+		}
 
         // Updating statistics
         var _stat = charStatisticsList[curCharName].general;
@@ -3162,9 +3173,11 @@ function _select_Gateway() { // Check for Gateway used to
                 
         
         var runSCAtime = !charStatisticsList[charNamesList[lastCharNum]].general.lastSCAVisit || ((charStatisticsList[charNamesList[lastCharNum]].general.lastSCAVisit + (1000*60*60*24)) < Date.now());
+        var scaNotToday = charStatisticsList[charNamesList[lastCharNum]].general.lastSCAVisit < accountSettings.generalSettings.SCADailyReset;
         var sca_setting = getSetting('generalSettings','runSCA'); 
         var runSCA = (runSCAtime && (sca_setting !== 'never'));
         runSCA = runSCA && (sca_setting === 'always' || (sca_setting === 'free' && chardelay > 7000)); // More than 7 seconds for the next char swap
+        runSCA = runSCA || (sca_setting === "once" && scaNotToday);
         console.log("Check if need to run SCA for " + charNamesList[lastCharNum] + ":  " + sca_setting + " " + runSCAtime);                
         
         if (runSCA) {
@@ -4325,6 +4338,7 @@ function _select_Gateway() { // Check for Gateway used to
             html += "</tr>";
         });
         html += "</table>";
+        html += "<div style='margin: 5px 0;'> Last SCA reset: " + (new Date(accountSettings.generalSettings.SCADailyReset)).toLocaleString() + "</div>";
         $('#sca_v').html(html);
         $('#sca_v').append("<br /><br /><button id='settings_sca'>Cycle SCA</button>");
         

--- a/main.js
+++ b/main.js
@@ -1819,7 +1819,6 @@ function _select_Gateway() { // Check for Gateway used to
         {scope: 'account', group: 'generalSettings', name: 'runSCA', title: tr('settings.account.runSCA'),               type: 'select',   pane: 'main', tooltip: tr('settings.account.runSCA.tooltip'),
             opts: [ { name: 'never',        value: 'never'}, 
                     { name: 'free time',    value: 'free'}, 
-                    { name: 'reset detection (testing purpose)',   value: 'once'},
                     { name: 'always',       value: 'always'}],
             },        
         {scope: 'account', group: 'professionSettings', name: 'fillOptionals',   type: 'checkbox', pane: 'prof',    title: 'Fill Optional Assets',  tooltip: 'Enable to include selecting the optional assets of tasks'},
@@ -1856,7 +1855,6 @@ function _select_Gateway() { // Check for Gateway used to
         {scope: 'char', group: 'generalSettings', name: 'runSCA',    title: 'Run SCA',               type: 'select',   pane: 'main', tooltip: 'Running SCA adventures reward after professions',
             opts: [ { name: 'never',        value: 'never'}, 
                     { name: 'free time',    value: 'free'}, 
-                    { name: 'reset detection (testing purpose)',   value: 'once'},
                     { name: 'always',       value: 'always'}],
             },        
         
@@ -3172,12 +3170,12 @@ function _select_Gateway() { // Check for Gateway used to
         
                 
         
-        var runSCAtime = !charStatisticsList[charNamesList[lastCharNum]].general.lastSCAVisit || ((charStatisticsList[charNamesList[lastCharNum]].general.lastSCAVisit + (1000*60*60*24)) < Date.now());
-        var scaNotToday = charStatisticsList[charNamesList[lastCharNum]].general.lastSCAVisit < accountSettings.generalSettings.SCADailyReset;
+        var runSCAtime = !charStatisticsList[charNamesList[lastCharNum]].general.lastSCAVisit 
+                      || ((charStatisticsList[charNamesList[lastCharNum]].general.lastSCAVisit + (1000*60*60*24)) < Date.now())
+                      || (charStatisticsList[charNamesList[lastCharNum]].general.lastSCAVisit < accountSettings.generalSettings.SCADailyReset);
         var sca_setting = getSetting('generalSettings','runSCA'); 
         var runSCA = (runSCAtime && (sca_setting !== 'never'));
         runSCA = runSCA && (sca_setting === 'always' || (sca_setting === 'free' && chardelay > 7000)); // More than 7 seconds for the next char swap
-        runSCA = runSCA || (sca_setting === "once" && scaNotToday);
         console.log("Check if need to run SCA for " + charNamesList[lastCharNum] + ":  " + sca_setting + " " + runSCAtime);                
         
         if (runSCA) {

--- a/main.js
+++ b/main.js
@@ -1629,6 +1629,7 @@ function _select_Gateway() { // Check for Gateway used to
             refineAD: true,
             openRewards: false,
             runSCA: 'free',
+            SCADailyReset: Date.now() - 24*60*60*1000,
         },
         consolidationSettings: {
             bankCharName: "",
@@ -1818,6 +1819,7 @@ function _select_Gateway() { // Check for Gateway used to
         {scope: 'account', group: 'generalSettings', name: 'runSCA', title: tr('settings.account.runSCA'),               type: 'select',   pane: 'main', tooltip: tr('settings.account.runSCA.tooltip'),
             opts: [ { name: 'never',        value: 'never'}, 
                     { name: 'free time',    value: 'free'}, 
+                    { name: 'after server reset',   value: 'once'},
                     { name: 'always',       value: 'always'}],
             },        
         {scope: 'account', group: 'professionSettings', name: 'fillOptionals',   type: 'checkbox', pane: 'prof',    title: 'Fill Optional Assets',  tooltip: 'Enable to include selecting the optional assets of tasks'},
@@ -1854,6 +1856,7 @@ function _select_Gateway() { // Check for Gateway used to
         {scope: 'char', group: 'generalSettings', name: 'runSCA',    title: 'Run SCA',               type: 'select',   pane: 'main', tooltip: 'Running SCA adventures reward after professions',
             opts: [ { name: 'never',        value: 'never'}, 
                     { name: 'free time',    value: 'free'}, 
+                    { name: 'after server reset',   value: 'once'},
                     { name: 'always',       value: 'always'}],
             },        
         
@@ -2993,6 +2996,14 @@ function _select_Gateway() { // Check for Gateway used to
 
         // MAC-NW (endchanges)
 
+        // detect when daily reset occurs (no more frequently than every 16 hours)
+        var oldRefineToday = charStatisticsList[curCharName].general.refined | 0;
+        var newRefineToday = unsafeWindow.client.dataModel.model.ent.main.currencies.diamondsconverted | 0;
+        if (newRefineToday < oldRefineToday) {
+			if (accountSettings.generalSettings.SCADailyReset < Date.now() - 16*60*60*1000) {
+				accountSettings.generalSettings.SCADailyReset = Date.now();
+			}
+		}
 
         // Updating statistics
         var _stat = charStatisticsList[curCharName].general;
@@ -3162,9 +3173,11 @@ function _select_Gateway() { // Check for Gateway used to
                 
         
         var runSCAtime = !charStatisticsList[charNamesList[lastCharNum]].general.lastSCAVisit || ((charStatisticsList[charNamesList[lastCharNum]].general.lastSCAVisit + (1000*60*60*24)) < Date.now());
+        var scaNotToday = charStatisticsList[charNamesList[lastCharNum]].general.lastSCAVisit < accountSettings.generalSettings.SCADailyReset;
         var sca_setting = getSetting('generalSettings','runSCA'); 
         var runSCA = (runSCAtime && (sca_setting !== 'never'));
         runSCA = runSCA && (sca_setting === 'always' || (sca_setting === 'free' && chardelay > 7000)); // More than 7 seconds for the next char swap
+        runSCA = runSCA || (sca_setting === "once" && scaNotToday);
         console.log("Check if need to run SCA for " + charNamesList[lastCharNum] + ":  " + sca_setting + " " + runSCAtime);                
         
         if (runSCA) {
@@ -4325,6 +4338,7 @@ function _select_Gateway() { // Check for Gateway used to
             html += "</tr>";
         });
         html += "</table>";
+        html += "<div style='margin: 5px 0;'> Last SCA reset: " + (new Date(accountSettings.generalSettings.SCADailyReset)).toLocaleString() + "</div>";
         $('#sca_v').html(html);
         $('#sca_v').append("<br /><br /><button id='settings_sca'>Cycle SCA</button>");
         


### PR DESCRIPTION
- detect when daily reset occurs, based on the reduced amount of refined today AD (but not often than every 16 h)
- new setting "SCADailyReset" - stores information about last SCA reset time and is displayed on "SCA & Visit" tab
- run SCA when current character SCA Visit < SCADailyReset
