### PR TITLE
addProfile() serious bug correction

### DIFF
--- a/main.js
+++ b/main.js
@@ -346,12 +346,17 @@ function addProfile(profession, profile, base){
         profiles: []
     };
 
+    var baseProfileByName;
+    if (typeof(profession) ==='string') {
+        $.each(definedTask, function(index, value) {
+            if (value.taskListName === profession) baseProfileByName = value;
+        });
+    }
     
-
     //creating new profession or using existing one 
     var professionSet = (typeof profession === 'object')
         ? jQuery.extend(true, professionBase, profession)
-        : definedTask[profession] || professionBase;
+        : baseProfileByName || professionBase;
     
     if(!professionSet) {return;}
     if(!definedTask[profession]) {definedTask[profession] = professionSet;}
@@ -1810,7 +1815,6 @@ function addProfile(profession, profile, base){
         customProfiles = [];
     };
     customProfiles.forEach(function (cProfile, idx) {
-        if (!cProfile.profile.hasOwnProperty('recursiveList')){ cProfile.profile.recursiveList = false;}
         addProfile(cProfile.taskName, cProfile.profile, cProfile.baseProfile);
     });
     


### PR DESCRIPTION
addProfile() function assumes that keys in definedTask array are equal to taskListName property of object stored in this array, eg. definedTask["Leadership"].taskListName === "Leadership"
But this isn't true for Black Ice Shaping, Siege Event and Winter Event.
As a result we can not add with addProfile() function new profiles to these professions.
In fact, this function creates for these profession new entry in definedTask array with keys
"BlackIce", "SiegeEvent" and "WinterEvent", but these entries are lost when tasklist array is created.
Of course, this also applies to custom profiles.
